### PR TITLE
Remove additive sync mode to simplify functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The new modular structure in `src/` provides better separation of concerns:
 
 1. **src/core/sync_engine.py** - Core synchronization engine
    - Platform-agnostic sync operations
-   - Support for multiple sync modes (Mirror, Update, Additive)
+   - Support for multiple sync modes (Mirror, Update)
    - Dry-run capability for previewing changes
    - Progress reporting with cancellation support
    - File filtering and bandwidth limiting

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A modern, modular file synchronization tool with profile management, designed fo
 - **Sync Modes**:
   - **Update**: Only sync newer files
   - **Mirror**: Make destination exactly match source
-  - **Additive**: Only add new files, never delete
 - **Sync Directions**:
   - Remote → Local
   - Local → Remote
@@ -116,11 +115,6 @@ Each profile contains:
 - Makes destination exactly match source
 - Deletes files not in source
 - Best for: Exact replicas
-
-### Additive Mode
-- Only adds new files to destination
-- Never deletes anything
-- Best for: Archiving
 
 ## Advanced Features
 

--- a/src/models/sync_profile.py
+++ b/src/models/sync_profile.py
@@ -15,7 +15,6 @@ class SyncDirection(Enum):
 class SyncMode(Enum):
     MIRROR = "mirror"  # Exact copy, delete extra files
     UPDATE = "update"  # Only update newer files
-    ADDITIVE = "additive"  # Only add new files, never delete
 
 
 @dataclass

--- a/src/ui/profile_editor.py
+++ b/src/ui/profile_editor.py
@@ -148,8 +148,7 @@ class ProfileEditorDialog:
         
         for value, text, tooltip in [
             (SyncMode.UPDATE.value, "Update", "Only copy newer files"),
-            (SyncMode.MIRROR.value, "Mirror", "Make destination exactly match source"),
-            (SyncMode.ADDITIVE.value, "Additive", "Only add new files, never delete")
+            (SyncMode.MIRROR.value, "Mirror", "Make destination exactly match source")
         ]:
             btn = ttk.Radiobutton(mode_frame, text=text, variable=self.mode_var, value=value)
             btn.pack(side=tk.LEFT, padx=(0, 10))


### PR DESCRIPTION
## Summary
- Removes the additive sync mode option from the application
- Simplifies the codebase by eliminating redundant functionality

## Changes
- Removed `ADDITIVE` enum value from `SyncMode` class in `src/models/sync_profile.py`
- Updated profile editor UI to remove additive option from sync mode selection
- Cleaned up documentation references in README.md and CLAUDE.md

## Rationale
The additive sync mode was essentially the default rsync behavior without any special flags (no --delete, no --update). This made it redundant, as users can achieve similar results with the update mode by being selective with their sync configurations.

Removing this option simplifies the user interface and reduces confusion about which sync mode to choose.

Fixes #1

## Test plan
- [ ] Verify existing profiles still load correctly
- [ ] Confirm sync mode selection in profile editor only shows Update and Mirror options
- [ ] Test that Update and Mirror modes still function as expected
- [ ] Check that documentation accurately reflects available sync modes